### PR TITLE
refactor(): prefix variable names and remove unused color variables

### DIFF
--- a/scss/_buttons.scss
+++ b/scss/_buttons.scss
@@ -1,25 +1,25 @@
 .pe-btn {
-  @include button($btn-default-bg, $btn-default-border, $btn-default-text,
-    $btn-default-disabled-bg, $btn-default-disabled-text);
-  font-size: $btn-font-size;
-  line-height: $btn-line-height;
-  padding: 0 $btn-padding;
+  @include button($pe-btn-default-bg, $pe-btn-default-border, $pe-btn-default-text,
+    $pe-btn-default-disabled-bg, $pe-btn-default-disabled-text);
+  font-size: $pe-btn-font-size;
+  line-height: $pe-btn-line-height;
+  padding: 0 $pe-btn-padding;
 }
 
 .pe-btn--primary {
-  @include button($btn-primary-bg, $btn-primary-border, $btn-primary-text,
-    $btn-primary-disabled-bg, $btn-primary-disabled-text);
+  @include button($pe-btn-primary-bg, $pe-btn-primary-border, $pe-btn-primary-text,
+    $pe-btn-primary-disabled-bg, $pe-btn-primary-disabled-text);
 }
 
 .pe-btn--small {
-  font-size: $btn-font-size * 0.928571;
-  line-height: $btn-line-height * 0.857143;
-  padding: 0 ($btn-padding * 0.833333);
+  font-size: $pe-btn-font-size * 0.928571;
+  line-height: $pe-btn-line-height * 0.857143;
+  padding: 0 ($pe-btn-padding * 0.833333);
 }
 
 .pe-btn--large {
-  font-size: $btn-font-size * 1.285714;
-  line-height: $btn-line-height * 1.5;
-  padding: 0 ($btn-padding * 1.666667);
+  font-size: $pe-btn-font-size * 1.285714;
+  line-height: $pe-btn-line-height * 1.5;
+  padding: 0 ($pe-btn-padding * 1.666667);
 }
 

--- a/scss/_card.scss
+++ b/scss/_card.scss
@@ -1,13 +1,13 @@
 .pe-card {
-  border: $card-border;
+  border: $pe-card-border;
 }
 
 .pe-card__header,
 .pe-card__content {
-  padding: $card-heading-padding;
+  padding: $pe-card-heading-padding;
 }
 
 .pe-card__header {
-  border-bottom: $card-border;
+  border-bottom: $pe-card-border;
 }
 

--- a/scss/_reset.scss
+++ b/scss/_reset.scss
@@ -21,8 +21,8 @@ html {
 //
 
 html {
-  font-family: map-get($font-families, default-sans-serif);
+  font-family: map-get($pe-font-families, default-sans-serif);
   // Set a base font size for all elements. Font sizes for
   // other elements should be relative, using `rem` units.
-  font-size: $font-size-base;
+  font-size: $pe-font-size-base;
 }

--- a/scss/_type.scss
+++ b/scss/_type.scss
@@ -9,5 +9,5 @@ p {
 pre,
 code,
 kbd {
-  font-family: map-get($font-families, default-monospace);
+  font-family: map-get($pe-font-families, default-monospace);
 }

--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -4,56 +4,34 @@
 // Type
 //
 
-$font-size-base: 16px !default;
-$font-families: (
+$pe-font-size-base: 16px !default;
+$pe-font-families: (
   default-sans-serif: ('Helvetica Neue', Helvetica, Arial, sans-serif),
   default-serif: (Georgia, Times, 'Times New Roman', serif),
   default-monospace: ('Lucida Sans Typewriter', 'Lucida Console', monaco, 'Bitstream Vera Sans Mono', monospace)
 ) !default;
 
-// Colors
-//
-// Foundational color palettes
-
-$primary-color: #00bbad !default;
-$primary-color-lightest: #62d3cb !default;
-$primary-color-lighter: #2cc2b7 !default;
-$primary-color-darker: #00847a !default;
-$primary-color-darkest: #005d56 !default;
-
-$secondary-color: #ffcb00 !default;
-$secondary-color-lightest: #ffe377 !default;
-$secondary-color-lighter: #ffd73a !default;
-$secondary-color-darker: #d6ab00 !default;
-$secondary-color-darkest: #977900 !default;
-
-$accent-color: #e00072 !default;
-$accent-color-lightest: #ea6dad !default;
-$accent-color-lighter: #e3338d !default;
-$accent-color-darker: #b0005a !default;
-$accent-color-darkest: #7c003f !default;
-
 // Buttons
 //
 
-$btn-default-bg: #f8f8f8 !default;
-$btn-default-border: #d0d0d0 !default;
-$btn-default-text: #666666 !default;
-$btn-default-disabled-bg: #cccccc !default;
-$btn-default-disabled-text: #888888 !default;
+$pe-btn-default-bg: #f8f8f8 !default;
+$pe-btn-default-border: #d0d0d0 !default;
+$pe-btn-default-text: #666666 !default;
+$pe-btn-default-disabled-bg: #cccccc !default;
+$pe-btn-default-disabled-text: #888888 !default;
 
-$btn-primary-bg: #107aca !default;
-$btn-primary-border: #0e6ab0 !default;
-$btn-primary-text: #ffffff !default;
-$btn-primary-disabled-bg: #9dc0db !default;
-$btn-primary-disabled-text: #ffffff !default;
+$pe-btn-primary-bg: #107aca !default;
+$pe-btn-primary-border: #0e6ab0 !default;
+$pe-btn-primary-text: #ffffff !default;
+$pe-btn-primary-disabled-bg: #9dc0db !default;
+$pe-btn-primary-disabled-text: #ffffff !default;
 
-$btn-font-size: 0.875rem !default;
-$btn-line-height: 1.75rem !default;
-$btn-padding: 12px !default;
+$pe-btn-font-size: 0.875rem !default;
+$pe-btn-line-height: 1.75rem !default;
+$pe-btn-padding: 12px !default;
 
 // Card
 //
 
-$card-border: solid 1px #cccccc !default;
-$card-heading-padding: 15px !default;
+$pe-card-border: solid 1px #cccccc !default;
+$pe-card-heading-padding: 15px !default;


### PR DESCRIPTION
To stay consistent with Origami practices, prefixing Sass variables with `pe-`. I also removed the placeholder color variables.

Reviewer: @dstack 