### PR TITLE
Sass lint

### DIFF
--- a/.sass-lint.yml
+++ b/.sass-lint.yml
@@ -1,0 +1,241 @@
+rules:
+
+  # "border: 0" not "border: none"
+  border-zero: 2
+
+  # .foo {
+  # }
+  brace-style:
+    - 2
+    - style: 1tbs
+      allow-single-line: true
+
+  # @import 'foo';
+  clean-import-paths:
+    - 1
+    - filename-extension: false
+      leading-underscore: false
+
+  # Nested blocks should include a space between last non-comment
+  # declaration:
+  # .foo {
+  #   display: block;
+  #
+  #   .bar {
+  #   }
+  # }
+  empty-line-between-blocks: 1
+
+  # @extend should be written before declarations in a ruleset
+  extends-before-declarations: 1
+
+  # @extend should be written before mixins in a ruleset
+  extends-before-mixins: 1
+
+  # Files should end with a newline
+  final-newline:
+    - 1
+    - include: true
+
+  # Do not force element nesting
+  force-element-nesting: 0
+
+  # Do not forse pseudo element nesting
+  force-pseudo-nesting: 0
+
+  # Function name format:
+  # @function foo-bar()
+  function-name-format:
+    - 2
+    - convention: "^[a-z][a-zA-Z0-9\\-]+$"
+
+  # Disallow short hex definitions
+  hex-length:
+    - 2
+    - style: long
+
+  # Hex values should be lowercase
+  hex-notation:
+    - 1
+    - style: lowercase
+
+  # Indent with two spaces
+  indentation:
+    - 2
+    - size: 2
+
+  # Decimal numbers must include a leading 0
+  leading-zero:
+    - 2
+    - include: true
+
+  # Mixin name format:
+  # @mixin foo-bar()
+  mixin-name-format:
+    - 2
+    - convention: "^[a-z][a-zA-Z0-9\\-]+$"
+
+  # Allow mixins after declarations in a ruleset
+  mixins-before-declarations: 0
+
+  # Max nesting depth is 3
+  nesting-depth:
+    - 1
+    - max-depth: 3
+
+  # Should use hex color values rather than literals
+  no-color-keywords: 1
+
+  # Allow color literals as function arguments
+  no-color-literals: 0
+
+  # Allow CSS comments
+  no-css-comments: 0
+
+  # Disallow @debug statements
+  no-debug: 2
+
+  # Duplicate properties are not allowed within the same block
+  no-duplicate-properties: 1
+
+  # Disallow empty rulesets
+  no-empty-rulesets: 2
+
+  # Disallow id selectors
+  no-ids: 1
+
+  # Disallow !important
+  # no-important: 1
+  # Note: allowing !important until we can disable inline
+  # using comments.
+  # See https://github.com/sasstools/sass-lint/issues/70
+  no-important: 0
+
+  # Ensure hex values are valid
+  no-invalid-hex: 1
+
+  # Allow mergeable selectors
+  no-mergeable-selectors: 0
+
+  # Enforce correct spelling of CSS properties
+  no-misspelled-properties:
+    - 1
+    - extra-properties:
+        - text-size-adjust
+        - osx-font-smoothing
+
+  # Disallow qualifying elements:
+  # div.foo
+  # ul#foo
+  no-qualifying-elements:
+    - 2
+    - allow-element-with-attribute: false
+      allow-element-with-class: false
+      allow-element-with-id: false
+
+  # Disallow trailing zeroes
+  no-trailing-zero: 1
+
+  # Allow transition: all
+  no-transition-all: 0
+
+  # Allow protocols and domains in URLs
+  no-url-protocols: 0
+
+  # Disallow vendor prefixes
+  no-vendor-prefixes:
+    - 1
+    - excluded-identifiers:
+      - user-select
+      - appearance
+      - font-smoothing
+      # Not working
+      - webkit-font-smoothing
+      - moz-osx-font-smoothing
+      # Allow webkit and moz for now
+      - webkit
+      - moz
+
+  # Disallow placeholders in @extend
+  placeholder-in-extend: 2
+
+  # Placeholder name format
+  placeholder-name-format:
+    - 2
+    - convention: "^[a-z_][a-zA-Z0-9_\\-]+$"
+
+  # Ignore sort order
+  property-sort-order: 0
+
+  # Single quotes: @import 'foo';
+  quotes:
+    - 2
+    - style: single
+
+  # Values in shorthand form must be as concise as possible
+  shorthand-values: 2
+
+  # Selectors must be on a single line
+  single-line-per-selector: 2
+
+  # Disallow space after bang
+  space-after-bang:
+    - 2
+    - include: false
+
+  # Must have a space after colon
+  # Right: color: '#000000';
+  # Wrong: color:'#000000';
+  space-after-colon:
+    - 2
+    - include: true
+
+  # Must have a space after comma
+  # Right: rgb(0, 0, 0)
+  # Wrong: rgb(0,0,0)
+  space-after-comma: 2
+
+  # Must have a space before bang
+  # Right: content: 'foo' !important;
+  # Wrong: content: 'foo'!important;
+  space-before-bang:
+    - 2
+    - include: true
+
+  # Must have a space before brace
+  # Right: .foo {
+  # Wrong: .foo{
+  space-before-brace:
+    - 2
+    - include: true
+
+  # Disallow space before colon
+  # Right: content: 'foo'
+  # Wrong: content : 'foo'
+  space-before-colon:
+    - 2
+    - include: false
+
+  # Disallow space between parentheses
+  # Right: @function foo($bar)
+  # Wrong: @function foo( $bar )
+  space-between-parens:
+    - 2
+    - include: false
+
+  # All declarations must have a trailing semicolon
+  trailing-semicolon: 2
+
+  # url('example.com') not url(example.com)
+  url-quotes: 0
+
+  # Do not enforce use of variables for specified properties
+  variable-for-property: 0
+
+  # Variable name format: $foo-bar
+  variable-name-format:
+    - 2
+    - convention: "^[a-z][a-zA-Z0-9\\-]+$"
+
+  # Allow omitting units for 0 values
+  zero-unit: 0

--- a/docs/scss/_header.scss
+++ b/docs/scss/_header.scss
@@ -1,15 +1,15 @@
 .d-header-github-link {
-    display: block;
-    width: 32px;
-    height: 32px;
-    margin-top: 6px;
-    opacity: 0.5;
-    background-size: cover;
-    transition: all 0.2s ease-in-out;
+  display: block;
+  width: 32px;
+  height: 32px;
+  margin-top: 6px;
+  opacity: 0.5;
+  background-size: cover;
+  transition: all 0.2s ease-in-out;
 
-    &:hover,
-    &:active,
-    &:focus {
-      opacity: 0.9;
-    }
+  &:hover,
+  &:active,
+  &:focus {
+    opacity: 0.9;
+  }
 }

--- a/docs/scss/docs.scss
+++ b/docs/scss/docs.scss
@@ -1,8 +1,8 @@
-@import "../../scss/elements";
+@import '../../scss/elements';
 
-@import "variables";
-@import "demo";
-@import "docs-layout";
-@import "header";
-@import "images";
-@import "syntax";
+@import 'variables';
+@import 'demo';
+@import 'docs-layout';
+@import 'header';
+@import 'images';
+@import 'syntax';

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -3,6 +3,7 @@
 const gulp = require('gulp');
 const rename = require('gulp-rename');
 const sass = require('gulp-sass');
+const sassLint = require('gulp-sass-lint');
 const postcss = require('gulp-postcss');
 const autoprefixer = require('autoprefixer');
 const nano = require('gulp-cssnano');
@@ -23,6 +24,18 @@ gulp.task('clean', () => {
     '_gh_pages',
     'npm-debug.log'
   ]);
+});
+
+gulp.task('lint', () => {
+  gulp.src([
+    './scss/**/*.scss',
+    '!./scss/_normalize.scss',
+    './docs/scss/**/*.scss',
+    '!./docs/scss/_syntax.scss'
+  ])
+    .pipe(sassLint())
+    .pipe(sassLint.format())
+    .pipe(sassLint.failOnError());
 });
 
 gulp.task('build-docs', ['sass'], (done) => {

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   },
   "scripts": {
     "start": "gulp",
+    "lint": "gulp lint",
     "test": "exit 0",
     "build-docs": "gulp build-docs",
     "gen-changelog": "node ./npm_scripts/gen-changelog.js",
@@ -32,6 +33,7 @@
     "gulp-postcss": "^6.0.1",
     "gulp-rename": "^1.2.2",
     "gulp-sass": "^2.1.0",
+    "gulp-sass-lint": "^1.1.0",
     "highlight.js": "^8.9.1",
     "markdown-it": "^5.0.2",
     "metalsmith": "^2.1.0",

--- a/scss/_mixins.scss
+++ b/scss/_mixins.scss
@@ -1,5 +1,5 @@
-@import "mixins/buttons";
-@import "mixins/fonts";
-@import "mixins/header";
-@import "mixins/responsive-breakpoints";
-@import "mixins/visibility";
+@import 'mixins/buttons';
+@import 'mixins/fonts';
+@import 'mixins/header';
+@import 'mixins/responsive-breakpoints';
+@import 'mixins/visibility';

--- a/scss/_tables.scss
+++ b/scss/_tables.scss
@@ -10,23 +10,23 @@ table,
     padding: 8px;
     line-height: 1.42857143;
     vertical-align: top;
-    border-top: 1px solid #ddd;
+    border-top: 1px solid $pe-table-border-color;
     text-align: left;
   }
 
   thead th {
     vertical-align: bottom;
-    border-bottom: 2px solid #ddd;
+    border-bottom: 2px solid $pe-table-border-color;
     border-top: 0px none;
   }
 
   tbody + tbody {
-    border-bottom: 2px solid #ddd;
+    border-bottom: 2px solid $pe-table-border-color;
   }
 }
 
 .pe-table--striped {
   tbody tr:nth-of-type(odd) {
-    background-color: #e8e8e8;
+    background-color: $pe-table-striped-bg;
   }
 }

--- a/scss/_type.scss
+++ b/scss/_type.scss
@@ -16,10 +16,15 @@ a {
 // Headings
 //
 
-h1, h2, h3, h4, h5, h6 {
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
   small {
-    font-size: 0.8em;
-    color: #555;
+    font-size: $pe-text-heading-small-font-size;
+    color: $pe-text-heading-small-color;
   }
 }
 
@@ -82,16 +87,16 @@ kbd {
 }
 
 code {
-  color: #555;
+  color: $pe-text-code-color;
 }
 
 kbd {
   padding: 2px 4px;
-  background: #333;
-  color: #fff;
+  background: $pe-text-kbd-bg;
+  color: $pe-text-kbd-color;
   font-size: 90%;
   border-radius: 3px;
-  box-shadow: inset 0 -1px 0 rgba(0,0,0,.25);
+  box-shadow: inset 0 -1px 0 rgba(0, 0, 0, 0.25);
 
   kbd {
     padding: 0;

--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -30,6 +30,12 @@ $pe-font-families: (
 $pe-link-color: #0d65a6 !default;
 $pe-link-hover-color: #094877 !default;
 
+// Headings
+//
+
+$pe-text-heading-small-color: #555555 !default;
+$pe-text-heading-small-font-size: 0.8rem !default;
+
 // Inline text
 //
 
@@ -40,6 +46,14 @@ $pe-text-strikethrough-color: #676767 !default;
 $pe-text-small-line-height: 1rem !default;
 $pe-text-small-font-weight: normal !default;
 $pe-text-small-font-size: inherit !default;
+
+// Code
+//
+
+$pe-text-code-color: #555555 !default;
+
+$pe-text-kbd-bg: #333333 !default;
+$pe-text-kbd-color: #ffffff !default;
 
 // Body copy
 //
@@ -175,6 +189,12 @@ $pe-header-link-hover-color: #f2f2f2 !default;
 
 $pe-header-nav-link-active-bg: #4d4d4d !default;
 $pe-header-nav-link-padding-x: 15px !default;
+
+// Tables
+//
+
+$pe-table-striped-bg: #e8e8e8 !default;
+$pe-table-border-color: #dddddd !default;
 
 // z-index
 //

--- a/scss/elements.scss
+++ b/scss/elements.scss
@@ -1,14 +1,14 @@
 // normalize.css
-@import "normalize";
+@import 'normalize';
 
 // Elements
-@import "variables";
-@import "mixins";
-@import "reset";
-@import "aside";
-@import "buttons";
-@import "card";
-@import "header";
-@import "responsive-utilities";
-@import "tables";
-@import "type";
+@import 'variables';
+@import 'mixins';
+@import 'reset';
+@import 'aside';
+@import 'buttons';
+@import 'card';
+@import 'header';
+@import 'responsive-utilities';
+@import 'tables';
+@import 'type';

--- a/scss/mixins/_responsive-breakpoints.scss
+++ b/scss/mixins/_responsive-breakpoints.scss
@@ -29,13 +29,13 @@
     @if ($_to > 1) {
       $_min-breakpoint: nth($breakpoint, $_to - 1);
       $_return: map-merge($_return, (
-        min: pe-responsive-get-breakpoint-value($_min-breakpoint, min)
+          min: pe-responsive-get-breakpoint-value($_min-breakpoint, min)
       ));
     }
 
     $_max-breakpoint: nth($breakpoint, $_to + 1);
     $_return: map-merge($_return, (
-      max: pe-responsive-get-breakpoint-value($_max-breakpoint, max)
+        max: pe-responsive-get-breakpoint-value($_max-breakpoint, max)
     ));
   } @else {
     $_min-breakpoint: nth($breakpoint, 1);
@@ -47,11 +47,11 @@
 
 @function pe-responsive-get-breakpoint-value($breakpoint, $bound) {
   @if not index(min max, $bound) {
-    @error "$bound must be min or max"
+    @error '$bound must be min or max'
   }
 
   @if not index(map-keys($pe-responsive-breakpoints), $breakpoint) {
-    @error "$breakpoint was not recognized: #{$breakpoint}"
+    @error '$breakpoint was not recognized: #{$breakpoint}'
   }
 
   $_return: map-get($pe-responsive-breakpoints, $breakpoint);


### PR DESCRIPTION
@dstack Configured sass-lint with rules closely matching the scss-lint configuration in origami-build-tools and fixed all of the errors/warnings. This does not configure Travis—that will come soon—but once this is merged `npm run lint` should be passing prior to opening new PRs.