### PR TITLE
feat: comment-typo-tests

### DIFF
--- a/test/shell_scripts/tests_build_status.sh
+++ b/test/shell_scripts/tests_build_status.sh
@@ -2,7 +2,7 @@
 
 REPO_URI="https://api.travis-ci.org/repos/Pearson-Higher-Ed/ux-test-platform/builds"
 
-echo "Waiting for approximately 15s for the tests to trigger..."
+echo "Waiting for approximately 15s for the Selenium tests to trigger..."
 echo ""
 #The 15s sleep is to allow Travis to trigger the tests: ux-test-platform repo
 sleep 15
@@ -12,16 +12,17 @@ sleep 15
 # Setting a maximum time for the tests build to run, however once we get the status to passed/failed, we will return to the elements build run
 
 i=1
-max=300
+max=600 #Increase the max time to run the tests by 300 secs. This is because the test repo is growing.
 while [ $i -lt $max ]
 do
 
-echo "--------------------------------------------"
-echo "Polling for the tests run build status..."
-
 curl -i -H "Accept: application/vnd.travis-ci.2+json" $REPO_URI > test.json	
 LATEST_STATE=$(grep -o '"state":.[a-z\"]*' test.json | head -1)
-#LATEST_ID=$(grep -o '"id":.[0-9]*' test.json | head -1 | grep ':.[0-9]*')
+LATEST_ID=$(grep -o '"id":.[0-9]*' test.json | head -1 | grep ':.[0-9]*')
+
+echo "--------------------------------------------"
+echo "Polling for the tests run build status..."
+echo "ux-test-platform build id: $LATEST_ID"
 
 get_state_value=${LATEST_STATE#*:}
 STATE="${get_state_value//\"}"

--- a/test/spec/type.js
+++ b/test/spec/type.js
@@ -1,7 +1,7 @@
 /* global fixture hexToRgb assertCssPropertiesAreEqual getElementById expect */
 describe('type', () => {
 
-  afterEach(() => {
+  /*afterEach(() => {
     fixture.cleanup();
   });
 
@@ -510,6 +510,6 @@ describe('type', () => {
       ]);
     });
 
-  });
+  });*/
 
 });


### PR DESCRIPTION
- Comment typography tests in Karma. I moved all of them to selenium.
- Increase the polling time in tests_build_status.sh file, since there are more tests in selenium to run.
- echo the ux-test-platform build id. This helps to know which ux-test-platform build is been run.