### PR TITLE
feat(inputs): add text input styles

### DIFF
--- a/docs/elements/inputs.md
+++ b/docs/elements/inputs.md
@@ -4,6 +4,89 @@ title: Inputs
 section: elements
 ---
 
+
+<aside>
+Label-input pairs are wrapped in divs in order to have a single unit that can be styled and moved around. The `pe-inlineblock` class on a container will make these divs line up horizontally.
+</aside>
+
+## Single-line input fields
+
+Text input form elements are to be used for single line text inputs.
+
+{{#demo}}
+<div class="pe-inlineblock"> 
+  <div class="pe-input">
+    <label for="i1">Text label</label>
+    <input type="text" id="i1" value="Basic text input field">
+  </div>
+
+  <div class="pe-input pe-input--small">
+    <label for="i2">Text label</label>
+    <input type="text" id="i2" value="Small text input field">
+  </div>
+</div>
+{{/demo}}
+
+### Placeholder
+
+Placeholders can be used to give additional information about the format of data.
+
+{{#demo}}
+<div class="pe-input">
+  <label for="i3">Text label</label>
+  <input type="text" id="i3" placeholder="Basic text input field" value="">
+</div>
+
+<div class="pe-input pe-input--small">
+  <label for="i4">Text label</label>
+  <input type="text" id="i4" placeholder="Small text input field" value="">
+</div>
+{{/demo}}
+
+### Readonly
+
+To prevent the user from interacting with the field. The `pe-input--readonly` class is only for styling; the readonly attribute *must* be applied to make the field function as readonly.
+
+{{#demo}}
+<div class="pe-input pe-input--readonly">
+  <label for="i5">Text label</label>
+  <input type="text" id="i5" value="Readonly" readonly>
+</div>
+{{/demo}}
+
+### Disabled
+
+This state is a form input that is unavailable for interaction. The `pe-input--disabled` class is only for styling; the disabled attribute *must* be applied to make the field function as disabled.
+
+{{#demo}}
+<div class="pe-input pe-input--disabled">
+  <label for="i6">Text label</label>
+  <input type="text" id="i6" value="Disabled" disabled>
+</div>
+
+<div class="pe-input pe-input--disabled">
+  <label for="i7">Text label</label>
+  <input type="text" id="i7" placeholder="disabled with a placeholder" value="" disabled>
+</div>
+{{/demo}}
+
+### Error
+
+This field is used when a field has been filled out incorrectly. This state should always be paired with an explanatory message, which either must be inside the label element *or* if a separate element is used, it must have an id and the input must have a matching `aria-describedby` attribute.
+
+{{#demo}}
+<div class="pe-input pe-input--error">
+  <label for="i8">Text label <span class="pe-error-text">something went wrong!</span></label>
+  <input type="text" id="i8" value="Error">
+</div>
+
+<div class="pe-input pe-input--error">
+  <label for="i9">Text label </label>
+  <input type="text" id="i9" aria-describedby="i9-error" value="Error">
+  <p id="i9-error" class="pe-error-text">Something went wrong!</p>
+</div>
+{{/demo}}
+
 ## Checkboxes
 
 Checkboxes are for times when the user needs to make one or more binary choices about a related item. Type attribute of "Checkbox" also represents a state or option that can be toggled.

--- a/scss/_inputs.scss
+++ b/scss/_inputs.scss
@@ -1,3 +1,51 @@
+// NOTE: this needs a better home!
+// display label-input pairs in a row
+
+.pe-inlineblock {
+  div {
+    display: inline-block;
+    vertical-align: middle;
+    margin: 0 0 1em 1em;
+  }
+
+  div:first-child {
+    margin-left: 0;
+  }
+}
+
+// input type=text etc
+
+.pe-input {
+  @include pe-input(
+    $pe-input-default-bg,
+    $pe-input-default-border,
+    $pe-input-default-text,
+    $pe-input-default-disabled-bg,
+    $pe-input-default-disabled-text
+  );
+
+  margin-bottom: 1em;//until Parker changes
+  
+  & label {
+    @include pe-label;
+
+    display: block;
+    margin-bottom: 6px;
+  }
+
+  & input {
+    display: inline-block;
+    vertical-align: middle;
+
+    font-size: $pe-input-font-size;
+    height: $pe-input-height;
+    line-height: $pe-input-default-line-height;
+    padding: $pe-input-padding;
+  }
+}
+
+// checks and radios
+
 .pe-checkbox,
 .pe-radio {
   & input,

--- a/scss/_mixins.scss
+++ b/scss/_mixins.scss
@@ -4,6 +4,7 @@
 @import 'mixins/fonts';
 @import 'mixins/header';
 @import 'mixins/body';
+@import 'mixins/inputs';
 @import 'mixins/lists';
 @import 'mixins/utilities';
 @import 'mixins/visibility';

--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -167,6 +167,38 @@ $pe-label-inverse-color: pe-color(white) !default;
 $pe-label-secondary-inverse-color: pe-color(gray-wash) !default;
 $pe-label-inverse-font-weight: 300 !default;
 
+// Inputs
+//
+
+$pe-input-border-radius: 3px !default;
+$pe-input-font-size: $pe-label-large-font-size !default;
+$pe-input-height: 36px !default;
+$pe-input-padding: 0 14px !default;
+
+$pe-input-default-bg: pe-color(white) !default;
+$pe-input-default-border: solid 1px pe-color(hairline-gray) !default;
+$pe-input-default-text: pe-color(pitch) !default;
+$pe-input-default-disabled-bg: pe-color(off-white) !default;
+$pe-input-default-disabled-text: pe-color(boring) !default;
+$pe-input-default-line-height: $pe-label-large-line-height !default;
+
+$pe-input-small-bg: $pe-input-default-bg !default;
+$pe-input-small-border: $pe-input-default-border !default;
+$pe-input-small-text: $pe-input-default-text !default;
+$pe-input-small-disabled-bg: $pe-input-default-disabled-bg !default;
+$pe-input-small-disabled-text: $pe-input-default-disabled-text !default;
+$pe-input-small-height: 28px !default;
+$pe-input-small-padding: 0 10px !default;
+$pe-input-small-font-size: $pe-label-font-size !default;
+$pe-input-small-line-height: $pe-label-line-height !default;
+$pe-input-readonly-bg: pe-color(off-white) !default;
+$pe-input-error-border: solid 1px #d0021b !default;
+$pe-input-error-text-color: #d0021b;
+$pe-input-error-box-shadow: 0px 0px 4px #d0021b !default;
+$pe-input-placeholder-color: #6d6d6d !default;
+$pe-input-placeholder-text: italic !default;
+
+
 // Aside
 //
 

--- a/scss/mixins/_inputs.scss
+++ b/scss/mixins/_inputs.scss
@@ -1,0 +1,70 @@
+@mixin pe-placeholder {
+  &::-webkit-input-placeholder { @content }
+  &::-moz-placeholder { @content }
+  &:-moz-placeholder { @content }
+  &:-ms-input-placeholder { @content }
+}
+
+@mixin pe-input(
+  $bg,
+  $border,
+  $color,
+  $disabled-bg,
+  $disabled-color,
+  $active-shadow: none
+) {
+
+  & input {
+    color: $color;
+    background: $bg;
+    border: $border;
+    border-radius: $pe-input-border-radius;
+
+    @include pe-placeholder {
+      font-style: $pe-input-placeholder-text;
+      color: $pe-input-placeholder-color;
+    }
+
+  }
+
+  & input:disabled,
+  &.pe-input--disabled input {
+    color: $disabled-color;
+    background: $disabled-bg;
+
+    @include pe-placeholder {
+      color: $disabled-color;
+    }
+
+  }
+
+  &.pe-input--readonly input {
+    background: $disabled-bg;
+  }
+
+  //these are not really supported yet, and interfere with earlier rule
+  & input:read-only,
+  & input:-moz-read-only {
+    background: $disabled-bg;
+  }
+
+  & input:invalid,
+  &.pe-input--error input {
+    border: $pe-input-error-border;
+    box-shadow: $pe-input-error-box-shadow;
+  }
+  
+  // to be placed on error messages
+
+  & .pe-error-text {
+    color: $pe-input-error-text-color;
+  }
+
+  &.pe-input--small input {
+    font-size: $pe-input-small-font-size;
+    height: $pe-input-small-height;
+    line-height: $pe-input-small-line-height;
+    padding: $pe-input-small-padding;
+  }
+
+}


### PR DESCRIPTION
I couldn't figure out how to style placeholders without vendor prefixes in a way that works, so they are not styled.

I had to make other changes: @umahaea @aaronkaka please check.