### PR TITLE
fix(inputs): manual add focus style to unselected radio button

### DIFF
--- a/scss/_inputs.scss
+++ b/scss/_inputs.scss
@@ -115,6 +115,12 @@
   }
 }
 
+// Firefox/Win doesn't show the radio groups being focussed on
+
+.pe-radio input:not(:checked):focus {
+  outline: 1px dotted $pe-input-default-text;
+}
+
 .pe-checkbox--small,
 .pe-radio--small,
 .pe-textarea--small {


### PR DESCRIPTION
@umahaea unchecked radio buttons have a style
outline: 1px dotted #231f20;