### PR TITLE
feat(inputs): update to Parker's check-radio focus styles

### DIFF
--- a/scss/_inputs.scss
+++ b/scss/_inputs.scss
@@ -115,6 +115,17 @@
   }
 }
 
+.pe-radio input:focus,
+.pe-checkbox input:focus {
+  outline: 1px solid $pe-link-color;
+  outline-offset: 2px;
+}
+.mouseDetected .pe-radio input:not(:checked):focus,
+.mouseDetected .pe-checkbox input:focus {
+  outline: 0;
+}
+
+
 .pe-checkbox--small,
 .pe-radio--small,
 .pe-textarea--small {


### PR DESCRIPTION
@umahaea 

checkboxes and unselected radios with focus should have 
`outline: 1px solid #0d65a6;`
 `outline-offset: 2px;`