### PR TITLE
feat(ci-test): Run tests against feature branch in CI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ _gh_pages
 .idea
 test/fixtures/color/*.json
 test.json
+elements.iml

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Forked repo will not trigger the 'ux-test-platform' tests. In the logs, you woul
  	cd elements
  	travis login --org *Provide your github login and password
  	travis token --org *Copy the access token
- 	travis ecrypt AUTH_TOKEN=access_token *Copy this token and replace it with env: global: secure: <<access_token>> in .travis.yml file
+ 	travis encrypt AUTH_TOKEN=access_token *Copy this token and replace it with env: global: secure: <<access_token>> in .travis.yml file
  	
  	Push this change and the ux-test-platform build would be triggered successfully.
 


### PR DESCRIPTION
Add more info to the Travis API that will trigger ux-test-platform's elements_sdk test suite only.
And export feature branch name to ux-test-platform, that way the tests point to feature_branch of elements only.
