### PR TITLE
fix: adjust inputs

### DIFF
--- a/docs/elements/inputs.md
+++ b/docs/elements/inputs.md
@@ -11,8 +11,8 @@ An input is a field used to elicit a response from a user
 {{#demo}}
   <div class="inputWrapper">
     <div class="pe-input-wrapper">
-      <label class="pe-textLabelInput__label">First Name</label>
-      <input type="text" class="pe-textInput" placeholder="First Name">
+      <label class="pe-textLabelInput__label" for="a">First Name</label>
+      <input type="text" class="pe-textInput" id="a" placeholder="First Name">
       <span class="pe-input_underline"></span>
     </div>
   </div>
@@ -23,8 +23,8 @@ An input is a field used to elicit a response from a user
 {{#demo}}
   <div class="inputWrapper">
     <div class="pe-input-wrapper">
-      <label class="pe-textLabelInput__label--label_error">First Name</label>
-      <input type="text" class="pe-textInput--input_error" placeholder="First Name"/>
+      <label class="pe-textLabelInput__label--label_error" for="b">First Name</label>
+      <input type="text" class="pe-textInput--input_error" id="b" placeholder="First Name"/>
       <span class="pe-inputError_underline"></span>
     </div>
   </div>
@@ -35,8 +35,8 @@ An input is a field used to elicit a response from a user
 {{#demo}}
   <div class="inputWrapper">
     <div class="pe-input-wrapper">
-      <label class="pe-textLabelInput__label" disabled>First Name</label>
-      <input type="text" class="pe-textInput" placeholder="First Name" disabled/>
+      <label class="pe-textLabelInput__label--label-disabled" for="c">First Name</label>
+      <input type="text" class="pe-textInput" id="c" value="Donald" disabled/>
     </div>
   </div>
 {{/demo}}
@@ -46,8 +46,8 @@ An input is a field used to elicit a response from a user
 {{#demo}}
   <div class="inputWrapper">
     <div class="pe-input-wrapper">
-      <label class="pe-textLabelInput__label" readonly>First Name</label>
-      <input type="text" class="pe-textInput" value="First Name" readonly/>
+      <label class="pe-textLabelInput__label" for="d">First Name</label>
+      <input type="text" class="pe-textInput--input_readonly" id="d" value="Donald" readonly/>
     </div>
   </div>
 {{/demo}}

--- a/scss/elements/inputs/_mixins.scss
+++ b/scss/elements/inputs/_mixins.scss
@@ -1,15 +1,25 @@
+@mixin pe-placeholder {
+  &::-webkit-input-placeholder { @content }
+  &::-moz-placeholder { @content }
+  &:-moz-placeholder { @content }
+  &:-ms-input-placeholder { @content }
+}
 
-@mixin textInput () {
+@mixin textInput() {
   %pe-textInput {
-    padding   :$textInput-padding;
-    font-size :$textInput-placeholder-font-size;
-    color     :$textInput-hintText-color;
-    width     :$textInput-width;
-    border    :$textInput-border-reset;
+    padding   : $textInput-padding;
+    font-size : $textInput-value-font-size;
+    color     : $textInput-value-color;
+    width     : $textInput-width;
+    border    : $textInput-border-reset;
+
+    @include pe-placeholder {
+      font-size : $textInput-placeholder-font-size;
+      color      : $textInput-placeholder-color;
+    }
+
     &:focus {
-      outline : none;
-      color   : $textInput-placeholder-color;
-      border  :$textInput-border-reset;
+      outline: none;
     }
 
   }
@@ -30,11 +40,11 @@
   }
 
 
-  .pe-textInput{
+  .pe-textInput {
     @extend %pe-textInput;
-    border-bottom      :$textInput-border-bottom;
-    border-bottom-style:$textInput-border-bottom-style;
-    border-bottom-color:$textInput-border-bottom-color;
+    border-bottom       : $textInput-border-bottom;
+    border-bottom-style : $textInput-border-bottom-style;
+    border-bottom-color : $textInput-border-bottom-color;
   }
 };
 
@@ -59,23 +69,23 @@
 
   .pe-textInput--input_error {
     @extend %pe-textInput;
-    border-bottom      :$textInput-error-border-bottom;
-    border-bottom-style:$textInput-error-border-bottom-style;
-    border-bottom-color:$textInput-error-border-bottom-color;
+    border-bottom       : $textInput-error-border-bottom;
+    border-bottom-style : $textInput-error-border-bottom-style;
+    border-bottom-color : $textInput-error-border-bottom-color;
   }
 
   .pe-input-wrapper{
-    height : 52px;
+    min-height : 52px;
   }
 
 };
 
 
 
-@mixin textInputLabel () {
-  .pe-textLabelInput__label	{
-    font-size:$textInput-label-font-size;
-    color    :$textInput-label-color;
+@mixin textInputLabel() {
+  .pe-textLabelInput__label {
+    font-size : $textInput-label-font-size;
+    color     : $textInput-label-color;
   }
 };
 
@@ -91,7 +101,8 @@
 
 
 @mixin textInputReadOnly() {
-  .pe-textInput[readonly] {
+  .pe-textInput--input_readonly {
+    @extend %pe-textInput;
     border-bottom : $textInput-readonly-border;
     color         : $textInput-readonly-text-color;
     font-size     : $textInput-readonly-text-font-size;
@@ -100,16 +111,18 @@
 
 
 @mixin textInputDisabled() {
-  .pe-textInput[disabled] {
-    border-bottom      :$textInput-disable-border-bottom;
-    border-bottom-style:$textInput-disable-border-bottom-style;
-    border-bottom-color:$textInput-disable-border-bottom-color;
+  .pe-textInput:disabled {
+    color               : $textInput-disable-text-color;
+    background-color    : $textInput-disable-background-color;
+    border-bottom       : $textInput-disable-border-bottom;
+    border-bottom-style : $textInput-disable-border-bottom-style;
+    border-bottom-color : $textInput-disable-border-bottom-color;
   }
 };
 
 
 @mixin textInputLabelDisabled() {
-  .pe-textInput__label[disabled] {
+  .pe-textLabelInput__label--label-disabled {
     color     : $textInput-disable-text-color;
     font-size : $textInput-disable-text-font-size;
   }

--- a/scss/elements/inputs/_variables.scss
+++ b/scss/elements/inputs/_variables.scss
@@ -14,14 +14,14 @@ $textInput-border-bottom       : 1px;
 $textInput-border-bottom-style : solid;
 $textInput-border-bottom-color : #6A7070;
 
-$textInput-placeholder-color     : #252525;
-$textInput-placeholder-font-size : 14pt;
+$textInput-value-color     : #252525;
+$textInput-value-font-size : 14pt;
 
 $textInput-label-color     : #6A7070;
 $textInput-label-font-size : 12pt;
 
-$textInput-hintText-color     : #C7C7C7;
-$textInput-hintText-font-size : 17px;
+$textInput-placeholder-color     : #C7C7C7;
+$textInput-placeholder-font-size : 14pt;
 
 //======textInput-Error==============
 
@@ -61,7 +61,7 @@ $textInput-focus-label-font-size : 14pt;
 
 
 //======disable=======================
-
+$textInput-disable-background-color    : #fff;
 $textInput-disable-border-bottom       : 1px;
 $textInput-disable-border-bottom-style : solid;
 $textInput-disable-border-bottom-color : #C7C7C7;
@@ -71,7 +71,7 @@ $textInput-disable-text-font-size : 14pt;
 
 //=======read-only====================
 
-$textInput-readonly-border         : none;
+$textInput-readonly-border         : 0;
 
 $textInput-readonly-text-color     : #252525;
 $textInput-readonly-text-font-size : 14pt;


### PR DESCRIPTION
I did the following:
* changed the colour variable name for the input value colours from "placeholder" to "value" and the hint ones to "placeholder"
* added a placeholder mixin to style placeholders
* adjusted the :disabled styles to match http://pearson-higher-ed.github.io/design/c/inputs/beta/
* adjusted the readonly styles to match the above
* added id's and for's to label-inputs and removed attributes from labels (because people copy code, especially people who don't know HTML and some of our customers will include non-HTML people)