### PR TITLE
fix: make button selectors more specific using beginning with and end…

### DIFF
--- a/scss/elements/buttons/_buttons.scss
+++ b/scss/elements/buttons/_buttons.scss
@@ -41,7 +41,7 @@
   border: 0;
 }
 
-[class*="pe-btn__primary"] {
+[class|="pe-btn__primary"] {
 
   @extend %btn;
 
@@ -57,7 +57,7 @@
 
 
 
-[class*="pe-btn__cta"] {
+[class|="pe-btn__cta"] {
 
   @extend %btn;
 
@@ -69,14 +69,14 @@
   );
 }
 
-[class*="--btn_small"] {
+[class$="--btn_small"] {
   height      : $pe-btn-small-height;
   font-size   : $pe-btn-small-font-size;
   line-height : $pe-btn-small-line-height;
   padding     : $pe-btn-small-padding;
 }
 
-[class*="--btn_large"] {
+[class$="--btn_large"] {
   height      : $pe-btn-large-height;
   font-size   : $pe-btn-large-font-size;
   line-height : $pe-btn-large-line-height;
@@ -85,10 +85,9 @@
 
 
 
-[class*="--btn_xlarge"]{
+[class$="--btn_xlarge"]{
   height      : $pe-btn-xlarge-height;
   font-size   : $pe-btn-xlarge-font-size;
   line-height : $pe-btn-xlarge-line-height;
   padding     : $pe-btn-xlarge-padding;
 }
-


### PR DESCRIPTION
…swith selectors

original issue from DES-583:
Button's class names that appends anything extra still renders the button. This will create inconsistency in the naming convention and not of a standard to our consumers.

For eg.
Correct class name is: pe-btn__primary--btn_large
Incorrect: 
pe-btn__primaryXYZ--btn_large
pe-btn__primary--btn_largeXYZ
pe-btn__primary@#%@$%@$%--btn_large#%@%@$%