### PR TITLE
fix: line-height on fake buttons

### DIFF
--- a/docs/elements/buttons.md
+++ b/docs/elements/buttons.md
@@ -4,7 +4,7 @@ title: Buttons
 section: elements
 ---
 
-Use a button to represent a user action&#8212; specifically, pressing it should perform an action on a page or document, rather than navigating a user elsewhere. These button styles are generally intended for content buttons rather than UI buttons. See below for UI buttons.
+Use a button to represent a user action&#8212; specifically, pressing it should perform an action on a page or document, rather than navigating a user elsewhere. These button styles are generally intended for content buttons rather than UI buttons. See below for <a href="#uibuttons">UI buttons</a>.
 
 {{#demo}}
 <button class="pe-btn">Default</button>
@@ -18,7 +18,8 @@ Button classes can be used with `<div>`, `<span>`, `<a>`, `<button>`, and `<inpu
 
 {{#demo}}
 <div class="pe-btn" tabindex="0" role="button">Div</div>
-<a href="#" class="pe-btn" role="button">Link</a>
+<a href="#void" class="pe-btn" role="button">Link</a>
+<a href="#void" class="pe-btn__primary--btn_large" role="button">Large Primary Link</a>
 <button type="button" class="pe-btn">Button</button>
 <input class="pe-btn" type="submit" value="Submit"> 
 <button type="button" class="pe-link">Button</button>
@@ -54,6 +55,7 @@ Buttons can be made smaller or larger.
 {{#demo}}
 <button class="pe-btn--btn_small">Small</button>
 <button class="pe-btn--btn_large">Large</button>
+<button class="pe-btn--btn_large pe-btn__cta">CTA Large</button>
 <button class="pe-btn--btn_xlarge">xLarge</button>
 <button class="pe-btn__primary--btn_xlarge">Primary xLarge</button>
 {{/demo}}
@@ -66,7 +68,7 @@ When the width of the button's text exceeds the container width, it will be trun
 <button class="pe-btn" style="max-width: 200px">The quick brown fox jumps over the lazy dog.</button>
 {{/demo}}
 
-## UI Buttons
+<h2 id="uibuttons">UI Buttons</h2>
 
 <script>if (!document.getElementById('pe-icons-sprite')) {
   var pe_ajax = new XMLHttpRequest();

--- a/scss/elements/buttons/_buttons.scss
+++ b/scss/elements/buttons/_buttons.scss
@@ -18,14 +18,14 @@
 %btn_small {
   height      : $pe-btn-small-height;
   font-size   : $pe-btn-small-font-size;
-  line-height : $pe-btn-small-line-height;
+  line-height : $pe-btn-small-height;
   padding     : $pe-btn-small-padding;
 }
 
 %btn_large {
   height      : $pe-btn-large-height;
   font-size   : $pe-btn-large-font-size;
-  line-height : $pe-btn-large-line-height;
+  line-height : $pe-btn-large-height;
   padding     : $pe-btn-large-padding;
 }
 
@@ -34,7 +34,7 @@
 %btn_xlarge{
   height      : $pe-btn-xlarge-height;
   font-size   : $pe-btn-xlarge-font-size;
-  line-height : $pe-btn-xlarge-line-height;
+  line-height : $pe-btn-xlarge-height;
   padding     : $pe-btn-xlarge-padding;
 }
 


### PR DESCRIPTION
also in docs:
made an in-page link to "ui buttons" (half-broken because sticky headers suck)
added different-size fake link button to show the line-height changes work
added a large-CTA example so we can point ppl to how to do that in the docs (instead of them asking us what class to use)