### PR TITLE
feature: Link style buttons with padding

### DIFF
--- a/docs/elements/buttons.md
+++ b/docs/elements/buttons.md
@@ -21,8 +21,9 @@ Button classes can be used with `<div>`, `<span>`, `<a>`, `<button>`, and `<inpu
 <a href="#void" class="pe-btn" role="button">Link</a>
 <a href="#void" class="pe-btn__primary--btn_large" role="button">Large Primary Link</a>
 <button type="button" class="pe-btn">Button</button>
-<input class="pe-btn" type="submit" value="Submit"> 
+<input class="pe-btn" type="submit" value="Submit">
 <button type="button" class="pe-link">Button</button>
+<button type="button" class="pe-link--btn">Link button 2.0</button>
 {{/demo}}
 
 <aside>
@@ -30,7 +31,7 @@ Button classes can be used with `<div>`, `<span>`, `<a>`, `<button>`, and `<inpu
   <p>Where possible, prefer native HTML buttons (<code>&lt;button&gt;</code>, <code>&lt;input type="button"&gt;</code> etc) over other elements styled as buttons, so that the User Agent and the OS do most of the work for you.</p>
   <p>If using an element other than a native HTML button, add the <a href="http://www.w3.org/TR/wai-aria/roles#button"><code>role="button"</code></a> attribute, and script in both click and keyup/down listeners (detect both spacebar and enter keys) to recreate button behavior. Also since buttons and inputs (but not divs, spans, or anchors) have a native disabled attribute, add <a href="http://www.w3.org/TR/wai-aria/states_and_properties#aria-disabled"><code>aria-disabled</code></a> to elements you want to disable, as well as manually changing the <code>tabindex</code> value to <code>"-1"</code> (or removing it in the case of non-natively focusables like div and span) to prevent average keyboarders from being able to tab to it (disabled elements cannot be in the tab order).</p>
 
-  <p>Another thing to be aware of that developers sometimes miss, is that because a focusable, interactive element is <strong>not</strong> allowed inside a button (ie, <span style="color:#b00;">&lt;button&gt; I'm button text &lt;a href="somewhere"&gt;with a link&lt;/a&gt;&lt;/button&gt;</span>), the same rule holds for divs or other elements turned into buttons with <code>tabindex</code> and <code>role=button</code>, even though an HTML validator currently won't flag this. This also holds true for polyfilled <code>details/summary</code> elements!</p> 
+  <p>Another thing to be aware of that developers sometimes miss, is that because a focusable, interactive element is <strong>not</strong> allowed inside a button (ie, <span style="color:#b00;">&lt;button&gt; I'm button text &lt;a href="somewhere"&gt;with a link&lt;/a&gt;&lt;/button&gt;</span>), the same rule holds for divs or other elements turned into buttons with <code>tabindex</code> and <code>role=button</code>, even though an HTML validator currently won't flag this. This also holds true for polyfilled <code>details/summary</code> elements!</p>
 </aside>
 
 ## Disabled

--- a/scss/elements/buttons/_buttons.scss
+++ b/scss/elements/buttons/_buttons.scss
@@ -2,7 +2,6 @@
 @import 'mixins';
 
 
-
 %btn{
   border-radius  : $pe-btn-standard-border-radius;
   border         : none;
@@ -38,7 +37,6 @@
   padding     : $pe-btn-xlarge-padding;
 }
 
-
 // For icons in buttons, remove buttony styles
 
 .pe-icon--btn {
@@ -49,13 +47,17 @@
 
 // for fake links
 
+.pe-link-extend {
+  text-decoration: underline;
+  background-color: transparent;
+  border: none;
+  cursor: pointer;
+}
+
 .pe-link {
   color: $pe-color-link;
-  text-decoration: underline;
   padding: 0;
-  background-color: transparent;
-  border: 0;
-  cursor: pointer;
+  @extend .pe-link-extend;
 
   &:hover,
   &:focus {
@@ -67,12 +69,8 @@
 .pe-link--btn {
   color: $pe-color-digital-pearson-blue;
   padding: 4px;
-  background-color: transparent;
-  border: none;
-  text-decoration: underline;
-  cursor: pointer;
+  @extend .pe-link-extend;
 }
-
 
 //===========btn=================================
 .pe-btn {
@@ -196,7 +194,6 @@
     $pe-btn-primary-disabled-text
   );
 }
-
 
 //===========CTA=================================
 .pe-btn__cta {

--- a/scss/elements/buttons/_buttons.scss
+++ b/scss/elements/buttons/_buttons.scss
@@ -64,6 +64,15 @@
   }
 }
 
+.pe-link--btn {
+  color: $pe-color-digital-pearson-blue;
+  padding: 4px;
+  background-color: transparent;
+  border: none;
+  text-decoration: underline;
+  cursor: pointer;
+}
+
 
 //===========btn=================================
 .pe-btn {


### PR DESCRIPTION
For reference on the discussion - https://agile-jira.pearson.com/browse/DES-610

I spoke with Tory and because these have a different use case than the other link style buttons, I have left out hover & focus state.  He said that will be handled on their end if needed.

