### PR TITLE
feature: error state select input

### DIFF
--- a/docs/elements/buttons.md
+++ b/docs/elements/buttons.md
@@ -24,6 +24,7 @@ Button classes can be used with `<div>`, `<span>`, `<a>`, `<button>`, and `<inpu
 <input class="pe-btn" type="submit" value="Submit">
 <button type="button" class="pe-link">Button</button>
 <button type="button" class="pe-link--btn">Link button 2.0</button>
+<button type="button" class="pe-link--btn" disabled>Disabled link button 2.0</button>
 {{/demo}}
 
 <aside>

--- a/docs/elements/inputs.md
+++ b/docs/elements/inputs.md
@@ -111,6 +111,27 @@ Select dropdowns are generally meant for times when a user needs to make a singl
 </div>
 {{/demo}}
 
+## Select Inputs - Basic (error)
+
+{{#demo}}
+<label class="pe-textLabelInput__label--label_error" for="ww">Error label</label>
+<div class="pe-select-container-error">
+  <select class="pe-selectInput--basic" id="ww">
+    <option value="uno">One</option>
+    <option value="dos">Two</option>
+    <option value="tres">Three</option>
+    <option value="quatro">Four</option>
+  </select>
+  <svg aria-hidden="true"
+    focusable="false"
+    class="pe-icon--dropdown-open-18">
+  <use xlink:href="#dropdown-open-18"></use>
+  </svg>
+</div>
+<p id="someError" class="pe-input--error_message">error message</p>
+
+{{/demo}}
+
 ## Multiple Line text
 
 {{#demo}}

--- a/scss/elements/buttons/_buttons.scss
+++ b/scss/elements/buttons/_buttons.scss
@@ -47,7 +47,7 @@
 
 // for fake links
 
-.pe-link-extend {
+%pe-link-extend {
   text-decoration: underline;
   background-color: transparent;
   border: none;
@@ -57,7 +57,7 @@
 .pe-link {
   color: $pe-color-link;
   padding: 0;
-  @extend .pe-link-extend;
+  @extend %pe-link-extend;
 
   &:hover,
   &:focus {
@@ -69,7 +69,7 @@
 .pe-link--btn {
   color: $pe-color-digital-pearson-blue;
   padding: 4px;
-  @extend .pe-link-extend;
+  @extend %pe-link-extend;
 }
 
 //===========btn=================================

--- a/scss/elements/buttons/_buttons.scss
+++ b/scss/elements/buttons/_buttons.scss
@@ -70,6 +70,10 @@
   color: $pe-color-digital-pearson-blue;
   padding: 4px;
   @extend %pe-link-extend;
+
+  &:disabled {
+    color: $pe-color-medium-gray;
+  }
 }
 
 //===========btn=================================

--- a/scss/elements/inputs/_basic-input-mixins.scss
+++ b/scss/elements/inputs/_basic-input-mixins.scss
@@ -65,35 +65,51 @@
 
 };
 
+.container-extend {
+  position: relative;
+  display: $textInput-basic-display;
+  min-width: $textInput-basic-select-minWidth;
+  padding: 0;
+}
+
+.container-extend-svg {
+  position: absolute;
+  bottom: $svg-bottom;
+  right: $svg-right;
+  pointer-events: none;
+}
+
+.container-extend-select {
+  box-sizing: border-box;
+  width: 100%;
+  min-height: 34px;
+  margin: 0;
+  padding: 0 14px;
+  outline: none;
+}
+
+.selectInput--basic-extend {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  background-color: $pe-color-white;
+  border: 1px solid transparent;
+  padding-top: 8px;
+}
+
 @mixin textInputBasicSelect() {
 
   .pe-select-container {
-    @extend .abstract;
-    position: relative;
-    display: $textInput-basic-display;
-    min-width: $textInput-basic-select-minWidth;
-    padding: 0;
+    @extend .abstract, .container-extend;
     border: $textInput-basic-border;
   }
 
   .pe-select-container svg {
-    position: absolute;
-    bottom: $svg-bottom;
-    right: $svg-right;
-    pointer-events: none;
-  }
-
-  .pe-textLabelInput__label {
-    display: $textInput-basic-display;
+    @extend .container-extend-svg;
   }
 
   .pe-select-container select {
-    box-sizing: border-box;
-    width: 100%;
-    min-height: 34px;
-    margin: 0;
-    padding: 0 14px;
-    outline: none;
+    @extend .container-extend-select;
   }
 
   .pe-select-container select:focus {
@@ -103,18 +119,7 @@
   }
 
   .pe-selectInput--basic {
-    -webkit-appearance: none;
-    -moz-appearance: none;
-    appearance: none;
-    background-color: $pe-color-white;
-    border: 1px solid transparent;
-    padding-top: 8px;
-
-    @include pe-placeholder {
-      font-size : $textInput-placeholder-font-size;
-      color     : $textInput-placeholder-color;
-    }
-
+    @extend .selectInput--basic-extend;
   }
 
   .pe-select-container select:focus::-ms-value {
@@ -128,6 +133,47 @@
   }
 
   .pe-select-container select::-ms-expand {
+    opacity: 0;
+  }
+
+};
+
+@mixin textInputBasicSelectError() {
+
+  .pe-select-container-error {
+    @extend .abstract, .container-extend;
+    border: $textInput-basic-error-border;
+  }
+
+  .pe-select-container-error svg {
+    @extend .container-extend-svg;
+  }
+
+  .pe-select-container-error select {
+    @extend .container-extend-select;
+  }
+
+  .pe-select-container-error select:focus {
+    outline: none;
+    border: $textInput-basic-error-border;
+    box-shadow: $textInput-basic-error-focus-boxShadow;
+  }
+
+  .pe-selectInput--basic {
+    @extend .selectInput--basic-extend;
+  }
+
+  .pe-select-container-error select:focus::-ms-value {
+		background: transparent;
+		color: #222;
+	}
+
+  .pe-selectInput--basic:-moz-focusring {
+    color: transparent;
+    text-shadow: 0 0 0 #000;
+  }
+
+  .pe-select-container-error select::-ms-expand {
     opacity: 0;
   }
 

--- a/scss/elements/inputs/_basic-input-mixins.scss
+++ b/scss/elements/inputs/_basic-input-mixins.scss
@@ -5,7 +5,7 @@
   &:-ms-input-placeholder { @content }
 };
 
-.abstract {
+%abstract {
   padding: $textInput-basic-padding;
   height: $textInput-basic-height;
   font-size: $textInput-value-font-size;
@@ -20,7 +20,7 @@
 @mixin textInputBasic() {
 
   .pe-textInput--basic {
-    @extend .abstract;
+    @extend %abstract;
     border: $textInput-basic-border;
 
     @include pe-placeholder {
@@ -40,7 +40,7 @@
 @mixin textInputBasicError() {
 
   .pe-textInput--basic_error {
-    @extend .abstract;
+    @extend %abstract;
     border: $textInput-basic-error-border;
 
     @include pe-placeholder {
@@ -65,21 +65,21 @@
 
 };
 
-.container-extend {
+%container-extend {
   position: relative;
   display: $textInput-basic-display;
   min-width: $textInput-basic-select-minWidth;
   padding: 0;
 }
 
-.container-extend-svg {
+%container-extend-svg {
   position: absolute;
   bottom: $svg-bottom;
   right: $svg-right;
   pointer-events: none;
 }
 
-.container-extend-select {
+%container-extend-select {
   box-sizing: border-box;
   width: 100%;
   min-height: 34px;
@@ -88,7 +88,7 @@
   outline: none;
 }
 
-.selectInput--basic-extend {
+%selectInput--basic-extend {
   -webkit-appearance: none;
   -moz-appearance: none;
   appearance: none;
@@ -100,16 +100,16 @@
 @mixin textInputBasicSelect() {
 
   .pe-select-container {
-    @extend .abstract, .container-extend;
+    @extend %abstract, %container-extend;
     border: $textInput-basic-border;
   }
 
   .pe-select-container svg {
-    @extend .container-extend-svg;
+    @extend %container-extend-svg;
   }
 
   .pe-select-container select {
-    @extend .container-extend-select;
+    @extend %container-extend-select;
   }
 
   .pe-select-container select:focus {
@@ -119,7 +119,7 @@
   }
 
   .pe-selectInput--basic {
-    @extend .selectInput--basic-extend;
+    @extend %selectInput--basic-extend;
   }
 
   .pe-select-container select:focus::-ms-value {
@@ -141,16 +141,16 @@
 @mixin textInputBasicSelectError() {
 
   .pe-select-container-error {
-    @extend .abstract, .container-extend;
+    @extend %abstract, %container-extend;
     border: $textInput-basic-error-border;
   }
 
   .pe-select-container-error svg {
-    @extend .container-extend-svg;
+    @extend %container-extend-svg;
   }
 
   .pe-select-container-error select {
-    @extend .container-extend-select;
+    @extend %container-extend-select;
   }
 
   .pe-select-container-error select:focus {
@@ -160,7 +160,7 @@
   }
 
   .pe-selectInput--basic {
-    @extend .selectInput--basic-extend;
+    @extend %selectInput--basic-extend;
   }
 
   .pe-select-container-error select:focus::-ms-value {

--- a/scss/elements/inputs/_inputs.scss
+++ b/scss/elements/inputs/_inputs.scss
@@ -28,6 +28,7 @@
 @include textInputBasicDisabled();
 
 @include textInputBasicSelect();
+@include textInputBasicSelectError();
 
 @include multiLineText();
 

--- a/scss/elements/inputs/_mixins.scss
+++ b/scss/elements/inputs/_mixins.scss
@@ -54,7 +54,7 @@
     padding-top: 3px;
     color: $pe-color-strawberry-red;
     font-size: $textInput-label-font-size;
-    line-height: $textInput-label-line-height; 
+    line-height: $textInput-label-line-height;
     margin-bottom: 0;
   }
 }
@@ -96,12 +96,14 @@
     font-size   : $textInput-label-font-size;
     color       : $textInput-label-color;
     line-height : $textInput-label-line-height;
+    display     : $textInput-basic-display;
   }
 
   .pe-textLabelInput__label--label_focus {
     font-size   : $textInput-label-font-size;
     color       : $textInput-focus-label-color;
     line-height : $textInput-label-line-height;
+    display     : $textInput-basic-display;
   }
 
 };
@@ -110,9 +112,10 @@
 
 @mixin textInputLabelError() {
   .pe-textLabelInput__label--label_error {
-    color     : $textInput-error-focus-label-color;
-    font-size : $textInput-error-focus-label-font-size;
+    color       : $textInput-error-focus-label-color;
+    font-size   : $textInput-error-focus-label-font-size;
     line-height : $textInput-label-line-height;
+    display     : $textInput-basic-display;
   }
 };
 
@@ -131,7 +134,7 @@
 @mixin textInputDisabled() {
   .pe-textInput:disabled {
     color               : $textInput-disable-text-color;
-    font-size           : $textInput-label-font-size;
+    font-size           : $textInput-value-font-size;
     background-color    : $textInput-disable-background-color;
     border-bottom       : $textInput-disable-border-bottom;
     border-bottom-style : $textInput-disable-border-bottom-style;

--- a/scss/elements/inputs/_variables.scss
+++ b/scss/elements/inputs/_variables.scss
@@ -155,7 +155,7 @@ $textInput-basic-error-focus-boxShadow : 0px 0px 4px 0px $pe-color-strawberry-re
 
 //=======textInput-basic-select========
 
-$textInput-basic-select-minWidth          : 250px;
+$textInput-basic-select-minWidth : 250px;
 
 $svg-bottom : 10px;
 $svg-right  : 14px;


### PR DESCRIPTION
- Error select for Console
- Addressed the spacing issue Nathan brought up by making all error-labels display: block
- Changed disabled fancy placeholder font-size to 14px per docs
- Small refactors; removed unnecessary @include from basic select (overzealous copy pasting on my part most likely) and moved pe-textLabelInput__label { display: etc } to where it's defined the first time instead of repeating multiple.