### PR TITLE
fix: remove outline: none on focusable elements

### DIFF
--- a/scss/elements/modal/_mixins.scss
+++ b/scss/elements/modal/_mixins.scss
@@ -52,7 +52,6 @@
             font-size          : 14px;
             line-height        : 22px;
             padding            : 0px 40px 0px 40px;
-            outline            : none;
           }
 
           .modalBody_border{
@@ -73,12 +72,7 @@
           }
 
           .modalSave{
-            outline : none;
             float   : right;
-          }
-
-          .modalCancel{
-            outline : none;
           }
 
           .modalClose{
@@ -87,7 +81,6 @@
             float            : right;
             margin           : -40px -40px 0px 0px;
             text-decoration  : none;
-            outline          : none;
             border           : none;
             background-color : inherit;
           }
@@ -117,7 +110,6 @@
             font-size          : 14px;
             line-height        : 22px;
             padding            : 0px 40px 0px 40px;
-            outline            : none;
           }
 
           .modalBody_border{
@@ -138,12 +130,7 @@
           }
 
           .modalSave{
-            outline : none;
-            float   : right;
-          }
-
-          .modalCancel{
-            outline : none;
+            float : right;
           }
 
           .modalClose{
@@ -152,7 +139,6 @@
             float            : right;
             margin           : -40px -40px 0px 0px;
             text-decoration  : none;
-            outline          : none;
             border           : none;
             background-color : inherit;
           }
@@ -182,7 +168,6 @@
             font-size          : 14px;
             line-height        : 22px;
             padding            : 0px 24px 0px 24px;
-            outline            : none;
           }
 
           .modalBody_border{
@@ -205,15 +190,13 @@
           }
 
           .modalSave{
-            outline : none;
-            flex    : 1 0 auto;
-            margin  : 6px 4px 6px 4px;
+            flex   : 1 0 auto;
+            margin : 6px 4px 6px 4px;
           }
 
           .modalCancel{
-            outline : none;
-            flex    : 1 0 auto;
-            margin  : 6px 4px 6px 4px;
+            flex   : 1 0 auto;
+            margin : 6px 4px 6px 4px;
           }
 
           .modalClose{
@@ -222,7 +205,6 @@
             float            : right;
             margin           : -24px -24px 0px 0px;
             text-decoration  : none;
-            outline          : none;
             border           : none;
             background-color : inherit;
           }
@@ -251,7 +233,6 @@
             font-size          : 14px;
             line-height        : 22px;
             padding            : 0px 24px 0px 24px;
-            outline            : none;
           }
 
           .modalBody_border{


### PR DESCRIPTION
this addresses Mallory's comments for the modal... basically removing the outline:none to allow default browser focus styles....