### PR TITLE
fix: move display none css code from visible to hidden class names

### DIFF
--- a/scss/elements/responsive-utilities/_responsive-utilities.scss
+++ b/scss/elements/responsive-utilities/_responsive-utilities.scss
@@ -8,9 +8,6 @@
 
 // Visible
 @each $breakpoint in map-keys($pe-responsive-breakpoints) {
-  .pe-#{$breakpoint}--visible {
-    display: none !important;
-  }
 
   @include pe-responsive-breakpoint($breakpoint to $breakpoint) {
     @include pe-visible('.pe-#{$breakpoint}--visible');
@@ -19,6 +16,10 @@
 
 // Hidden
 @each $breakpoint in map-keys($pe-responsive-breakpoints) {
+  .pe-#{$breakpoint}--hidden {
+    display: none !important;
+  }
+
   @include pe-responsive-breakpoint($breakpoint to $breakpoint) {
     @include pe-hidden('.pe-#{$breakpoint}--hidden');
   }


### PR DESCRIPTION
Borrowing a feature branch from the merge deprecation work.