### PR TITLE
chore: Add deprecated flag to description and warning to install

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pearson-elements",
   "version": "1.14.16",
-  "description": "CSS building blocks for Pearson web user experiences.",
+  "description": "**DEPRECATED** CSS building blocks for Pearson web user experiences.",
   "main": "./dist/css/elements.css",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Warning message on install is currently set to "Elements is no longer undergoing active development.  Please migrate over to @pearson-compounds/elements-sdk"