### PR TITLE
gh-232: Removing the cursor pointer from disabled link buttons

### DIFF
--- a/scss/elements/buttons/_buttons.scss
+++ b/scss/elements/buttons/_buttons.scss
@@ -69,6 +69,7 @@
   }
 
   &:disabled {
+    cursor: default;
     color: $pe-color-medium-gray;
     text-decoration: none;
   }


### PR DESCRIPTION
This fixes #232 